### PR TITLE
FrameLocator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <url>https://github.com/praegus/toolchain-playwright-fixture</url>
     <name>Praegus Toolchain Playwright Fixture</name>
     <description>A FitNesse fixture for writing browser tests using the Playwright Java API</description>
-    <version>1.6.6-SNAPSHOT</version>
+    <version>1.6.7-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.fitnesse</groupId>
             <artifactId>fitnesse</artifactId>
-            <version>20221219</version>
+            <version>20230503</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
             <organization>Praegus Solutions B.V.</organization>
             <organizationUrl>https://praegus.nl/solutions/</organizationUrl>
         </developer>
+        <developer>
+            <name>Michael de Lannoy</name>
+            <email>michael.de.lannoy@praegus.nl</email>
+            <organization>Praegus Connect B.V.</organization>
+            <organizationUrl>https://praegus.nl/connect/</organizationUrl>
+        </developer>
     </developers>
 
     <scm>

--- a/src/main/java/nl/praegus/fitnesse/slim/fixtures/playwright/PlaywrightFixture.java
+++ b/src/main/java/nl/praegus/fitnesse/slim/fixtures/playwright/PlaywrightFixture.java
@@ -790,6 +790,158 @@ public class PlaywrightFixture extends SlimFixtureBase {
         return path.startsWith(getWikiFilesDir()) ? path.subpath(1, (path.getNameCount())) : path;
     }
 
+    //FrameLocator
+
+    /**
+     * Clicks on an element within a frame
+     * Usage: | click | [selector] | frame | [frame] |
+     *
+     * @param selector playwright selector to locate element to click on.
+     * @param frame    playwright selector to locate a frame.
+     */
+    public void clickFrame(String selector, String frame) {
+        getLocatorFrame(selector, frame).click();
+    }
+
+    /**
+     * Fills an element with given value within a frame.
+     * Usage: | enter | [value] | into | [selector] | frame | [frame] |
+     *
+     * @param value    value to enter
+     * @param selector playwright selector to locate element to enter data in
+     * @param frame    playwright selector to locate a frame.
+     */
+    public void enterIntoFrame(String value, String selector, String frame) {
+        getLocatorFrame(selector, frame).fill(value);
+    }
+
+    /**
+     * Waits for an element to be visible within a frame.
+     * Usage: | wait for visible | [selector] | frame | [frame] |
+     *
+     * @param selector playwright selector to locate element to wait for
+     * @param frame    playwright selector to locate a frame.
+     */
+    public void waitForVisibleFrame(String selector, String frame) {
+        getLocatorFrame(selector, frame).waitFor();
+    }
+
+    /**
+     * Checks if an element is visible within a frame.
+     * Usage: | is visible | [selector] | frame | [frame] |
+     *
+     * @param selector playwright selector to locating the element to check.
+     * @param frame    playwright selector to locate a frame.
+     * @return boolean indicating if the element is visible
+     */
+    public boolean isVisibleFrame(String selector, String frame) {
+        return getLocatorFrame(selector, frame).isVisible();
+    }
+
+    /**
+     * Checks if an element is hidden within a frame.
+     * Usage: | is hidden | [selector] | frame | [frame] |
+     *
+     * @param selector playwright selector to locating the element to check.
+     * @param frame    playwright selector to locate a frame.
+     * @return boolean indicating if the element is hidden
+     */
+    public boolean isHiddenFrame(String selector, String frame) {
+        return getLocatorFrame(selector, frame).isHidden();
+    }
+
+    /**
+     * Gets the value of an element within a frame.
+     *
+     * @param selector playwright selector to locate the element to get the value from
+     * @param frame    playwright selector to locate a frame
+     * @return value of the given element
+     */
+    public String valueOfFrame(String selector, String frame) {
+        String result;
+        switch (getLocatorFrame(selector, frame).evaluate("e => e.tagName", null, new Locator.EvaluateOptions()).toString().toLowerCase()) {
+            case "input":
+            case "textarea":
+            case "select":
+                result = getLocatorFrame(selector, frame).inputValue();
+                break;
+            case "button":
+            case "option":
+            case "text":
+                result = getLocatorFrame(selector, frame).innerHTML();
+                break;
+            default:
+                result = getLocatorFrame(selector, frame).innerText();
+        }
+        return result;
+    }
+
+    /**
+     * Gets the for whitespace normalized value of an element within a frame.
+     *
+     * @param selector playwright selector to locate the element to get the normalized value from
+     * @param frame    playwright selector to locate a frame
+     * @return for whitespace normalized value of the element
+     */
+    public String normalizedValueOfFrame(String selector, String frame) {
+        return getNormalizedText(valueOfFrame(selector, frame));
+    }
+
+    /**
+     * Selects option by given value in select element within a frame.
+     *
+     * @param value    string of value to select
+     * @param selector playwright selector to locate element to select option in
+     * @param frame    playwright selector to locate a frame
+     */
+    public void selectValueInFrame(String value, String selector, String frame) {
+        getLocatorFrame(selector, frame).selectOption(value);
+    }
+
+    /**
+     * Selects option by given label in a select element within a frame.
+     *
+     * @param value    string of label to select
+     * @param selector playwright selector to locate element to select option in
+     * @param frame    playwright selector to locate a frame
+     */
+    public void selectLabelInFrame(String value, String selector, String frame) {
+        getLocatorFrame(selector, frame).selectOption(new SelectOption().setLabel(value));
+    }
+
+    /**
+     * Selects option by index in select element within a frame.
+     *
+     * @param index    index of option to select
+     * @param selector playwright selector to locate element to select option in
+     * @param frame    playwright selector to locate a frame
+     */
+    public void selectIndexInFrame(int index, String selector, String frame) {
+        getLocatorFrame(selector, frame).selectOption(new SelectOption().setIndex(index));
+    }
+
+    /**
+     * Checks if an element is checked within a frame.
+     *
+     * @param selector playwright selector to locating the element to check.
+     * @param frame    playwright selector to locate a frame
+     * @return boolean indicating if the element is checked
+     */
+    public boolean isCheckedFrame(String selector, String frame) {
+        return getLocatorFrame(selector, frame).isChecked();
+    }
+
+    /**
+     * Returns the number of elements matching the locator within a frame.
+     *
+     * @param selector playwright selector to count
+     * @param frame    playwright selector to locate a frame
+     * @return int number of times the given selector matches on the current page.
+     */
+    public int countFrame(String selector, String frame) {
+        return getLocatorFrame(selector, frame).count();
+    }
+
     //Debugging
 
     /**
@@ -1021,6 +1173,17 @@ public class PlaywrightFixture extends SlimFixtureBase {
      */
     private Locator getLocator(String selector) {
         return currentPage.locator(selector);
+    }
+
+    /**
+     * Helper function returning a Locator object based on a selector string within a frame.
+     *
+     * @param selector  playwright selector string
+     * @param frame     playwright selector to locate a frame.
+     * @return locator of an element on the current page
+     */
+    private Locator getLocatorFrame(String selector, String frame) {
+        return currentPage.frameLocator(frame).locator(selector);
     }
 
     /**

--- a/src/main/java/nl/praegus/fitnesse/slim/fixtures/playwright/PlaywrightFixture.java
+++ b/src/main/java/nl/praegus/fitnesse/slim/fixtures/playwright/PlaywrightFixture.java
@@ -667,22 +667,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @return value of the given element
      */
     public String valueOf(String selector) {
-        String result;
-        switch (getLocator(selector).evaluate("e => e.tagName", null, new Locator.EvaluateOptions()).toString().toLowerCase()) {
-            case "input":
-            case "textarea":
-            case "select":
-                result = getLocator(selector).inputValue();
-                break;
-            case "button":
-            case "option":
-            case "text":
-                result = getLocator(selector).innerHTML();
-                break;
-            default:
-                result = getLocator(selector).innerText();
-        }
-        return result;
+        return valueOfFrame(selector, "");
     }
 
     /**
@@ -800,7 +785,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @param frame    playwright selector to locate a frame.
      */
     public void clickFrame(String selector, String frame) {
-        getLocatorFrame(selector, frame).click();
+        getLocator(selector, frame).click();
     }
 
     /**
@@ -812,7 +797,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @param frame    playwright selector to locate a frame.
      */
     public void enterIntoFrame(String value, String selector, String frame) {
-        getLocatorFrame(selector, frame).fill(value);
+        getLocator(selector, frame).fill(value);
     }
 
     /**
@@ -823,7 +808,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @param frame    playwright selector to locate a frame.
      */
     public void waitForVisibleFrame(String selector, String frame) {
-        getLocatorFrame(selector, frame).waitFor();
+        getLocator(selector, frame).waitFor();
     }
 
     /**
@@ -835,7 +820,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @return boolean indicating if the element is visible
      */
     public boolean isVisibleFrame(String selector, String frame) {
-        return getLocatorFrame(selector, frame).isVisible();
+        return getLocator(selector, frame).isVisible();
     }
 
     /**
@@ -847,7 +832,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @return boolean indicating if the element is hidden
      */
     public boolean isHiddenFrame(String selector, String frame) {
-        return getLocatorFrame(selector, frame).isHidden();
+        return getLocator(selector, frame).isHidden();
     }
 
     /**
@@ -859,19 +844,19 @@ public class PlaywrightFixture extends SlimFixtureBase {
      */
     public String valueOfFrame(String selector, String frame) {
         String result;
-        switch (getLocatorFrame(selector, frame).evaluate("e => e.tagName", null, new Locator.EvaluateOptions()).toString().toLowerCase()) {
+        switch (getLocator(selector, frame).evaluate("e => e.tagName", null, new Locator.EvaluateOptions()).toString().toLowerCase()) {
             case "input":
             case "textarea":
             case "select":
-                result = getLocatorFrame(selector, frame).inputValue();
+                result = getLocator(selector, frame).inputValue();
                 break;
             case "button":
             case "option":
             case "text":
-                result = getLocatorFrame(selector, frame).innerHTML();
+                result = getLocator(selector, frame).innerHTML();
                 break;
             default:
-                result = getLocatorFrame(selector, frame).innerText();
+                result = getLocator(selector, frame).innerText();
         }
         return result;
     }
@@ -895,7 +880,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @param frame    playwright selector to locate a frame
      */
     public void selectValueInFrame(String value, String selector, String frame) {
-        getLocatorFrame(selector, frame).selectOption(value);
+        getLocator(selector, frame).selectOption(value);
     }
 
     /**
@@ -906,7 +891,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @param frame    playwright selector to locate a frame
      */
     public void selectLabelInFrame(String value, String selector, String frame) {
-        getLocatorFrame(selector, frame).selectOption(new SelectOption().setLabel(value));
+        getLocator(selector, frame).selectOption(new SelectOption().setLabel(value));
     }
 
     /**
@@ -917,7 +902,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @param frame    playwright selector to locate a frame
      */
     public void selectIndexInFrame(int index, String selector, String frame) {
-        getLocatorFrame(selector, frame).selectOption(new SelectOption().setIndex(index));
+        getLocator(selector, frame).selectOption(new SelectOption().setIndex(index));
     }
 
     /**
@@ -928,7 +913,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @return boolean indicating if the element is checked
      */
     public boolean isCheckedFrame(String selector, String frame) {
-        return getLocatorFrame(selector, frame).isChecked();
+        return getLocator(selector, frame).isChecked();
     }
 
     /**
@@ -939,7 +924,7 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @return int number of times the given selector matches on the current page.
      */
     public int countFrame(String selector, String frame) {
-        return getLocatorFrame(selector, frame).count();
+        return getLocator(selector, frame).count();
     }
 
     //Debugging
@@ -1182,8 +1167,8 @@ public class PlaywrightFixture extends SlimFixtureBase {
      * @param frame     playwright selector to locate a frame.
      * @return locator of an element on the current page
      */
-    private Locator getLocatorFrame(String selector, String frame) {
-        return currentPage.frameLocator(frame).locator(selector);
+    private Locator getLocator(String selector, String frame) {
+        return (frame.isEmpty()) ? getLocator(selector) : currentPage.frameLocator(frame).locator(selector);
     }
 
     /**


### PR DESCRIPTION
Adding FrameLocator commands. FrameLocator represents a view to the iframe on the page. It captures the logic sufficient to retrieve the iframe and locate elements in that iframe.

- Click on an element within a frame: 
`| click | [selector] | frame | [frame] |`

- Fill an element with given value within a frame.
`| enter | [value] | into | [selector] | frame | [frame] |`

- Wait for an element to be visible within a frame.
`| wait for visible | [selector] | frame | [frame] |`

- Check if an element is visible within a frame.
`| is visible | [selector] | frame | [frame] |`

- Check if an element is hidden within a frame.
`| is hidden | [selector] | frame | [frame] |`

- Get the value of an element within a frame.
`| value of | [selector] | frame | [frame] |`

- Get the for whitespace normalized value of an element within a frame.
`| normalized value of | [selector] | frame | [frame] |`

- Select option by given value in select element within a frame.
`| select value | [value] | in | [selector] | frame | [frame] |`

- Select option by given label in a select element within a frame.
`| select label | [value] | in | [selector] | frame | [frame] |`

- Select option by index in select element within a frame.
`| select index | [index] | in | [selector] | frame | [frame] |`

- Check if an element is checked within a frame.
`| is checked | [selector] | frame | [frame] |`

- Return the number of elements matching the locator within a frame.
`| count | [selector] | frame | [frame] |`