### PR TITLE
Added ForceClick command

### DIFF
--- a/src/main/java/nl/praegus/fitnesse/slim/fixtures/playwright/PlaywrightFixture.java
+++ b/src/main/java/nl/praegus/fitnesse/slim/fixtures/playwright/PlaywrightFixture.java
@@ -249,6 +249,15 @@ public class PlaywrightFixture extends SlimFixture {
     }
 
     /**
+     * Force clicks on an element
+     *
+     * @param selector playwright selector to locate element and bypass the actionability checks and force the click.
+     */
+    public void forceClick(String selector) {
+        getLocator(selector).click(new Locator.ClickOptions().setForce(true));
+    }
+
+    /**
      * Click on an element located by ARIA role and accessible name.
      *
      * @param role ARIA role


### PR DESCRIPTION
### Forcing the click
Sometimes, apps use non-trivial logic where hovering the element overlays it with another element that intercepts the click. This behavior is indistinguishable from a bug where element gets covered and the click is dispatched elsewhere. If you know this is taking place, you can bypass the [actionability](https://playwright.dev/java/docs/actionability) checks and force the click.

_reference: https://playwright.dev/java/docs/input#forcing-the-click_