### PR TITLE
Added setIgnoreHTTPSErrors

### DIFF
--- a/src/main/java/nl/praegus/fitnesse/slim/fixtures/playwright/PlaywrightSetup.java
+++ b/src/main/java/nl/praegus/fitnesse/slim/fixtures/playwright/PlaywrightSetup.java
@@ -84,6 +84,10 @@ public final class PlaywrightSetup extends SlimFixture {
         newContextOptions.setExtraHTTPHeaders(extraHTTPHeaders);
     }
 
+    public void SetIgnoreHttpsErrors(Boolean ignoreHttps) {
+        newContextOptions.setIgnoreHTTPSErrors(ignoreHttps);
+    }
+
     public void setBaseUrl(String baseUrl) {
         newContextOptions.setBaseURL(baseUrl);
     }


### PR DESCRIPTION
added [**setIgnoreHTTPSErrors** ](https://playwright.dev/java/docs/api/class-browser#browser-new-page-option-ignore-https-errors) _(boolean)_:

- Whether to ignore HTTPS errors when sending network requests. Defaults to _false_.